### PR TITLE
Add missing comma separator to version

### DIFF
--- a/requirements/pypi.txt
+++ b/requirements/pypi.txt
@@ -7,7 +7,7 @@
 # Binary (non-pure) packages may also be listed here, but you
 # should see if there is a conda package that suits your needs.
 
-Markdown>=3.0<3.3;python_version<"3.6"
+Markdown>=3.0,<3.3;python_version<"3.6"
 Markdown>=3.0;python_version>="3.6"
 typing;python_version<"3.5"
 pathlib2


### PR DESCRIPTION
The requirements specified in for `Markdown` are missing a required comma ([PEP 0508](https://peps.python.org/pep-0508/)). It seems like `pip` is able to deal with this issue gracefully, but other tools might not, like `uv`, which complains about the version specification being invalid.
